### PR TITLE
Add Go port of Java code

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module runix
+
+go 1.23.8

--- a/go/app/app.go
+++ b/go/app/app.go
@@ -1,0 +1,7 @@
+package app
+
+import "fmt"
+
+func HelloWorld() {
+	fmt.Println("Hello World!")
+}

--- a/go/cli/main.go
+++ b/go/cli/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("¡Bienvenido a Runix en Go!")
+	// Aquí iría la carga de archivos, parsing y ejecución.
+}

--- a/go/parser/token.go
+++ b/go/parser/token.go
@@ -1,0 +1,37 @@
+package parser
+
+type TokenType int
+
+const (
+	IDENTIFIER TokenType = iota
+	NUMBER
+	STRING
+	OPERATOR
+	EOF
+)
+
+type Token struct {
+	Type  TokenType
+	Value string
+}
+
+func (t Token) String() string {
+	return "[" + t.Type.String() + ": " + t.Value + "]"
+}
+
+func (tt TokenType) String() string {
+	switch tt {
+	case IDENTIFIER:
+		return "IDENTIFIER"
+	case NUMBER:
+		return "NUMBER"
+	case STRING:
+		return "STRING"
+	case OPERATOR:
+		return "OPERATOR"
+	case EOF:
+		return "EOF"
+	default:
+		return "UNKNOWN"
+	}
+}

--- a/go/parser/tokenizer.go
+++ b/go/parser/tokenizer.go
@@ -1,0 +1,88 @@
+package parser
+
+import (
+	"strings"
+)
+
+// Tokenizer performs basic lexical analysis over an input string.
+type Tokenizer struct {
+	input    string
+	position int
+}
+
+// NewTokenizer returns a tokenizer for the given input.
+func NewTokenizer(input string) *Tokenizer {
+	return &Tokenizer{input: input}
+}
+
+// Tokenize breaks the input into tokens.
+func (t *Tokenizer) Tokenize() []Token {
+	var tokens []Token
+	for t.position < len(t.input) {
+		current := t.input[t.position]
+
+		if isWhitespace(current) {
+			t.position++
+			continue
+		}
+
+		if isDigit(current) {
+			tokens = append(tokens, t.readNumber())
+			continue
+		}
+
+		if isLetter(current) {
+			tokens = append(tokens, t.readIdentifier())
+			continue
+		}
+
+		if strings.ContainsRune("+-*/=(){}", rune(current)) {
+			tokens = append(tokens, Token{Type: OPERATOR, Value: string(current)})
+			t.position++
+			continue
+		}
+
+		if current == '"' {
+			tokens = append(tokens, t.readString())
+			continue
+		}
+
+		t.position++
+	}
+
+	tokens = append(tokens, Token{Type: EOF, Value: ""})
+	return tokens
+}
+
+func (t *Tokenizer) readNumber() Token {
+	start := t.position
+	for t.position < len(t.input) && isDigit(t.input[t.position]) {
+		t.position++
+	}
+	return Token{Type: NUMBER, Value: t.input[start:t.position]}
+}
+
+func (t *Tokenizer) readIdentifier() Token {
+	start := t.position
+	for t.position < len(t.input) && (isLetter(t.input[t.position]) || isDigit(t.input[t.position])) {
+		t.position++
+	}
+	return Token{Type: IDENTIFIER, Value: t.input[start:t.position]}
+}
+
+func (t *Tokenizer) readString() Token {
+	t.position++ // skip starting quote
+	start := t.position
+	for t.position < len(t.input) && t.input[t.position] != '"' {
+		t.position++
+	}
+	result := t.input[start:t.position]
+	if t.position < len(t.input) {
+		t.position++ // skip ending quote
+	}
+	return Token{Type: STRING, Value: result}
+}
+
+func isWhitespace(ch byte) bool { return ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' }
+func isDigit(ch byte) bool      { return ch >= '0' && ch <= '9' }
+func isLetter(ch byte) bool     { return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') }

--- a/go/utils/helpers.go
+++ b/go/utils/helpers.go
@@ -1,0 +1,8 @@
+package utils
+
+import "fmt"
+
+// Log prints a label and value to stdout.
+func Log(label string, value interface{}) {
+	fmt.Printf("%s: %v\n", label, value)
+}


### PR DESCRIPTION
## Summary
- port Java tokenizer and helpers to Go
- include CLI entrypoint in Go
- add `go.mod` with module definition

## Testing
- `go build ./...`
- `go run go/cli/main.go`


------
https://chatgpt.com/codex/tasks/task_e_685afdff5e78833182a6f5036c2d608e