### PR TITLE
Add streaming support for OpenRouter client

### DIFF
--- a/go/cli/commands/commands.go
+++ b/go/cli/commands/commands.go
@@ -57,22 +57,22 @@ func usage() {
 // initializeSystem initializes the file manager, web server, and processor
 func initializeSystem() error {
 	var err error
-	
+
 	// Initialize file manager
 	globalFileManager, err = filemanager.NewFileManager()
 	if err != nil {
 		return fmt.Errorf("error inicializando gestor de archivos: %v", err)
 	}
-	
+
 	// Initialize web server
 	globalWebServer = webserver.NewServer(globalFileManager.GetProjectPath())
-	
+
 	// Initialize response processor
 	globalProcessor = processor.NewResponseProcessor(globalFileManager, globalWebServer)
-	
+
 	fmt.Println("🚀 Sistema Runix inicializado")
 	fmt.Printf("📁 Directorio de proyecto: %s\n", globalFileManager.GetProjectPath())
-	
+
 	return nil
 }
 
@@ -80,7 +80,7 @@ func initializeSystem() error {
 func setupCleanup() {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
-	
+
 	go func() {
 		<-c
 		fmt.Println("\n🧹 Limpiando...")
@@ -121,15 +121,23 @@ func chatCmd(args []string) {
 
 	client := openrouter.NewClient(apiKey)
 	animate("generando respuesta")
-	reply, err := client.Chat(*model, *context, fs.Arg(0))
+	stream, err := client.ChatStream(*model, *context, fs.Arg(0))
 	if err != nil {
 		fmt.Println("error:", err)
 		return
 	}
-	
-	// Process the response
-	processedReply := globalProcessor.ProcessResponse(reply)
-	chat("runix", processedReply)
+
+	var fullReply strings.Builder
+	for token := range stream {
+		fmt.Print(token)
+		fullReply.WriteString(token)
+	}
+	fmt.Println()
+
+	processedReply := globalProcessor.ProcessResponse(fullReply.String())
+	if processedReply != fullReply.String() {
+		chat("runix", processedReply)
+	}
 }
 
 func createCmd(args []string) {
@@ -157,7 +165,7 @@ func demoCmd(args []string) {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	
+
 	// Setup cleanup
 	setupCleanup()
 
@@ -171,7 +179,7 @@ func demoCmd(args []string) {
 	scanner := bufio.NewScanner(os.Stdin)
 	fmt.Println("Escribe 'exit' para terminar la conversación.")
 	fmt.Println("💡 Tip: Pide que cree HTML, CSS o JavaScript y se desplegará automáticamente en http://localhost:1111")
-	
+
 	for {
 		fmt.Print(":user: ")
 		if !scanner.Scan() {
@@ -185,17 +193,25 @@ func demoCmd(args []string) {
 			break
 		}
 		animate("generando respuesta")
-		reply, err := client.Chat(*model, *context, msg)
+		stream, err := client.ChatStream(*model, *context, msg)
 		if err != nil {
 			fmt.Println("error:", err)
 			continue
 		}
-		
-		// Process the response
-		processedReply := globalProcessor.ProcessResponse(reply)
-		chat("runix", processedReply)
+
+		var fullReply strings.Builder
+		for token := range stream {
+			fmt.Print(token)
+			fullReply.WriteString(token)
+		}
+		fmt.Println()
+
+		processedReply := globalProcessor.ProcessResponse(fullReply.String())
+		if processedReply != fullReply.String() {
+			chat("runix", processedReply)
+		}
 	}
-	
+
 	// Cleanup
 	if globalWebServer != nil {
 		globalWebServer.Stop()
@@ -212,10 +228,10 @@ func serverCmd(args []string) {
 		fmt.Printf("Error: %v\n", err)
 		return
 	}
-	
+
 	// Setup cleanup
 	setupCleanup()
-	
+
 	// Start server
 	if err := globalWebServer.Start(); err != nil {
 		fmt.Printf("Error iniciando servidor: %v\n", err)


### PR DESCRIPTION
## Summary
- improve error reporting in `openrouter.Client.Chat`
- add `ChatStream` for realtime streaming
- stream completions in `chat` and `demo` CLI commands

## Testing
- `go build ./...`
- `OPENROUTER_API_KEY=invalid_key go run ./go/cli chat "hola"` *(fails: No auth credentials found)*

------
https://chatgpt.com/codex/tasks/task_e_685b2131b1f4833198ff2c9accf22807